### PR TITLE
Bugfix: request buffer only when needed

### DIFF
--- a/lib/bit_iterator.js
+++ b/lib/bit_iterator.js
@@ -8,15 +8,15 @@ module.exports = function bitIterator(nextBuffer) {
     var f = function(n) {
         var result = 0;
         while(n > 0) {
+            if (byte >= bytes.length) {
+                byte = 0;
+                bytes = nextBuffer();
+            }
             var left = 8 - bit;
             if (n >= left) {
                 result <<= left;
                 result |= (BITMASK[left] & bytes[byte++]);
                 f.bytesRead++;
-                if (byte >= bytes.length) {
-                    byte = 0;
-                    bytes = nextBuffer();
-                }
                 bit = 0;
                 n -= left;
             } else {


### PR DESCRIPTION
Currently there is a bug depending on how chunks are split because if the requested bits consume all the available bits, bytes has no value.

By moving the buffer request, the code requests a buffer only when it needs it, lowering the potential of a bug.

This does not fix all the  Cannot read property '0' of undefined problems (I am still looking into it) but fixes one case I found when using { highWaterMark: 1} in long.js

