### PR TITLE
Fix browser-test

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "prepare": "mkdir dist && browserify -s unbzip2Stream index.js | uglifyjs >> dist/unbzip2-stream.min.js",
-    "browser-test": "browserify -t brfs test/simple.js | tape-run2 -b phantomjs",
+    "browser-test": "browserify -t brfs test/simple.js | tape-run",
     "prepare-long-test": "dd if=/dev/urandom of=test/fixtures/vmlinux.bin bs=50x1024x1024 count=2 && cat test/fixtures/vmlinux.bin | bzip2 > test/fixtures/vmlinux.bin.bz2",
     "long-test": "tape test/extra/long.js",
     "download-test": "beefy test/browser/long.js --open -- -t brfs",
@@ -39,7 +39,7 @@
     "browserify": "^8.1.0",
     "concat-stream": "^1.4.7",
     "tape": "^3.4.0",
-    "tape-run2": "^1.0.3",
+    "tape-run": "^4.0.0",
     "throughout": "0.0.0",
     "uglify-js": "^3.0.10"
   },

--- a/test/simple.js
+++ b/test/simple.js
@@ -69,17 +69,15 @@ test('should emit error when stream is broken in a different way?', function(t) 
     t.plan(1);
     // this is the smallest truncated file I found that reproduced the bug, but
     // longer files will also work.
-    var truncated = 'test/fixtures/truncated.bz2';
+    var truncated = fs.readFileSync('test/fixtures/brokencrc.bz2');
+    var unbz2 = unbzip2Stream();
+    unbz2.on('error', function (err) {
+        t.ok(true, err);
+    });
+    unbz2.on('close', function (err) {
+        t.ok(false, "Should not reach end of stream without failing.");
+    });
 
-    fs.createReadStream(truncated).
-        on('error', function (err) {
-            t.ok(false, "The file stream itself should not be failing.");
-        }).
-        pipe(unbzip2Stream()).
-        on('error', function (err) {
-            t.ok(true, err);
-        }).
-        on('close', function (err) {
-            t.ok(false, "Should not reach end of stream without failing.");
-        });
+    unbz2.write(truncated);
+    unbz2.end();
 });


### PR DESCRIPTION
tape-run2 is a now outdated fork of tape-run intended to circumvent
a bug that doesn't exist anymore. Also phantomjs was not included as
a dev dependency, so npm run browser-test did not work out of the box.
Switching back to tape-run brings in electron as the default test
browser, so use that instead.
One of the tests in simple.js used fs methods which doesn't work in
the browser test.