### PR TITLE
Do not truncate huffman buffers

### DIFF
--- a/lib/bzip2.js
+++ b/lib/bzip2.js
@@ -241,8 +241,8 @@ bzip2.decompress = function(bits, stream, buf, bufsize, streamCRC) {
 
         hufGroup.minLen = minLen;
         hufGroup.maxLen = maxLen;
-        var base = hufGroup.base.subarray(1);
-        var limit = hufGroup.limit.subarray(1);
+        var base = hufGroup.base;
+        var limit = hufGroup.limit;
         var pp = 0;
         for(var i = minLen; i <= maxLen; i++)
         for(var t = 0; t < symCount; t++)
@@ -271,8 +271,8 @@ bzip2.decompress = function(bits, stream, buf, bufsize, streamCRC) {
             symCount = GROUP_SIZE - 1;
             if (selector >= nSelectors) message.Error("meow i'm a kitty, that's an error");
             hufGroup = groups[this.selectors[selector++]];
-            base = hufGroup.base.subarray(1);
-            limit = hufGroup.limit.subarray(1);
+            base = hufGroup.base;
+            limit = hufGroup.limit;
         }
         i = hufGroup.minLen;
         j = bits(i);


### PR DESCRIPTION
One element of the buffers remained unused, causing a buffer overflow
for symbols encoded with 20 bits.