### PR TITLE
chore(readme): fix npm readme rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ fs.createReadStream('./test.bz2').pipe(bz2()).pipe(process.stdout);
 
 Also see [test/browser/download.js](https://github.com/regular/unbzip2-stream/blob/master/test/browser/download.js) for an example of decompressing a file while downloading.
 
-Or, using a <script> tag
+Or, using a &lt;script&gt; tag
 ---
 
 ```


### PR DESCRIPTION
It looks like npm really doesn't like it when there's a `<script>` tag in the readme. I'm hoping that it's just because markdown supports html tags, and they added some security measures - I imagine the `<script>` tags in the code fences will render out as `&lt;` etc so they shouldn't be a problem.

![image](https://user-images.githubusercontent.com/1348991/79814616-8ff52580-8333-11ea-9475-9a07ba115e71.png)